### PR TITLE
[examples/front-proxy] Sandbox for breaking max ejection percent

### DIFF
--- a/examples/front-proxy/docker-compose.yml
+++ b/examples/front-proxy/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - SERVICE_NAME=1
     expose:
       - "80"
+      - "81"
 
   service2:
     build:

--- a/examples/front-proxy/force_ejection.sh
+++ b/examples/front-proxy/force_ejection.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+cd "$(dirname "$0")"
+
+docker-compose down
+
+docker-compose up --build -d
+
+# Force some good traffic(200s)
+echo "Sending some good traffic..."
+for i in {1..10}; do curl -s -o /dev/null -w "%{http_code}\n" localhost:8000/service/1; done
+
+# Force some bad traffic(500s)
+echo "Sending some bad traffic..."
+for i in {1..10}; do curl -s -o /dev/null -w "%{http_code}\n" -H "fail:now" localhost:8000/service/1; done
+
+front_proxy_id=`docker ps --format "{{.ID}}:{{.Image}}" | grep frontproxy_front-envoy | cut -d: -f 1`
+
+# prints out ejections that were triggered.
+docker exec ${front_proxy_id} bash -c "cat /tmp/outliers.log"

--- a/examples/front-proxy/front-envoy.yaml
+++ b/examples/front-proxy/front-envoy.yaml
@@ -34,10 +34,15 @@ static_resources:
     type: strict_dns
     lb_policy: round_robin
     http2_protocol_options: {}
+    outlier_detection: {}
     hosts:
     - socket_address:
         address: service1
         port_value: 80
+    - socket_address:
+        address: service1
+        port_value: 81
+
   - name: service2
     connect_timeout: 0.25s
     type: strict_dns
@@ -53,3 +58,6 @@ admin:
     socket_address:
       address: 0.0.0.0
       port_value: 8001
+cluster_manager:
+  outlier_detection:
+    event_log_path: "/tmp/outliers.log"

--- a/examples/front-proxy/service-envoy.yaml
+++ b/examples/front-proxy/service-envoy.yaml
@@ -24,6 +24,30 @@ static_resources:
           http_filters:
           - name: envoy.router
             config: {}
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 81
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager
+        config:
+          codec_type: auto
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: service
+              domains:
+              - "*"
+              routes:
+              - match:
+                  prefix: "/service"
+                route:
+                  cluster: local_service
+          http_filters:
+          - name: envoy.router
+            config: {}
   clusters:
   - name: local_service
     connect_timeout: 0.25s

--- a/examples/front-proxy/service.py
+++ b/examples/front-proxy/service.py
@@ -1,5 +1,6 @@
 from flask import Flask
 from flask import request
+from flask import abort
 import socket
 import os
 import sys
@@ -19,10 +20,13 @@ TRACE_HEADERS_TO_PROPAGATE = [
 
 @app.route('/service/<service_number>')
 def hello(service_number):
-    return ('Hello from behind Envoy (service {})! hostname: {} resolved'
-            'hostname: {}\n'.format(os.environ['SERVICE_NAME'], 
-                                    socket.gethostname(),
-                                    socket.gethostbyname(socket.gethostname())))
+    if 'fail' in request.headers:
+        abort(500)
+    else:
+        return ('Hello from behind Envoy (service {})! hostname: {} resolved'
+                'hostname: {}\n'.format(os.environ['SERVICE_NAME'],
+                                        socket.gethostname(),
+                                        socket.gethostbyname(socket.gethostname())))
 
 @app.route('/trace/<service_number>')
 def trace(service_number):
@@ -34,7 +38,7 @@ def trace(service_number):
                 headers[header] = request.headers[header]
         ret = requests.get("http://localhost:9000/trace/2", headers=headers)
     return ('Hello from behind Envoy (service {})! hostname: {} resolved'
-            'hostname: {}\n'.format(os.environ['SERVICE_NAME'], 
+            'hostname: {}\n'.format(os.environ['SERVICE_NAME'],
                                     socket.gethostname(),
                                     socket.gethostbyname(socket.gethostname())))
 


### PR DESCRIPTION
**Motivation**

OutlierDetection.MaxEjectionPercent bills itself as a mechanism that will limit the percent of a cluster that will be ejected due to outlier detection:

> max_ejection_percent
> The maximum % of an upstream cluster that can be ejected due to outlier detection. Defaults to 10%.

However, this branch demonstrates that it isn't being honored. It:
- sets up the default outlier detection config and two different cluster entries into service1 at the front-proxy level
- updates the service script to return 500s when a `fail` header is specified in requests
- script that starts up docker, issues good and bad requests, then prints out the outlier detection log to show that a host is ejected.